### PR TITLE
OBD change investigation

### DIFF
--- a/spec/OBD/OBD.vspec
+++ b/spec/OBD/OBD.vspec
@@ -18,6 +18,12 @@
 # Some of these signals are also available through other nodes in the
 # VSS tree.
 #
+# Note that the VSS signals represent the real value, the actual encoding used by OBD is not considered
+#
+# Example: OilTemperature (PID 5C) can in OBD support the range from -40 degrees to + 210 degree celsius
+#          In OBD the value is transmitted as a uint8 with an offset of +40, i.e. +20 is transferred as +60
+#          In VSS the signal contains the actual temperature, i.e. +20 degrees is sent as +20
+#
 
 - PidsA:
   datatype: uint32
@@ -58,6 +64,7 @@
   datatype: string
   type: sensor
   description: PID 03 - Fuel status
+  # Issue: How is string supposed to be used here? Rather 2 Enums or 2 uint8 values?
 
 - EngineLoad:
   datatype: uint8
@@ -68,85 +75,99 @@
   description: PID 04 - Engine load in percent - 0 = no load, 100 = full load
 
 - CoolantTemperature:
-  datatype: float
+  datatype: int16
   type: sensor
   unit: celsius
+  min: -40
+  max: 215
   description: PID 05 - Coolant temperature
 
 - ShortTermFuelTrim1:
-  datatype: int8
+  datatype: float
   type: sensor
   unit: percent
   min: -100
-  max: 100
+  max: 99.2
   description: PID 06 - Short Term (immediate) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer
 
 - LongTermFuelTrim1:
-  datatype: int8
+  datatype: float
   type: sensor
   unit: percent
   min: -100
-  max: 100
+  max: 99.2
   description: PID 07 - Long Term (learned) Fuel Trim - Bank 1 - negative percent leaner, positive percent richer
 
 - ShortTermFuelTrim2:
-  datatype: int8
+  datatype: float
   type: sensor
   unit: percent
   min: -100
-  max: 100
+  max: 99.2
   description: PID 08 - Short Term (immediate) Fuel Trim - Bank 2 - negative percent leaner, positive percent richer
 
 - LongTermFuelTrim2:
-  datatype: int8
+  datatype: float
   type: sensor
   unit: percent
   min: -100
-  max: 100
+  max: 99.2
   description: PID 09 - Long Term (learned) Fuel Trim - Bank 2 - negative percent leaner, positive percent richer
 
 - FuelPressure:
-  datatype: float
+  datatype: uint16
   type: sensor
   unit: kPa
   min: 0
+  max: 765
   description: PID 0A - Fuel pressure
 
 - MAP:
-  datatype: float
+  datatype: uint8
   type: sensor
   unit: kPa
   min: 0
+  max: 255
   description: PID 0B - Intake manifold pressure
 
 - EngineSpeed:
   datatype: float
   type: sensor
   unit: rpm
+  min: 0
+  max: 16383.75
   description: PID 0C - Engine speed measured as rotations per minute
 
 - Speed:
-  datatype: float
+  datatype: uint8
   type: sensor
   unit: km/h
+  min: 0
+  max: 255
   description: PID 0D - Vehicle speed
 
 - TimingAdvance:
   datatype: float
   type: sensor
   unit: degrees
+  min: -64
+  max: 63.5
   description: PID 0E - Time advance
 
 - IntakeTemp:
-  datatype: float
+  datatype: int16
   type: sensor
   unit: celsius
+  min: -40
+  max: 215
   description: PID 0F - Intake temperature
 
 - MAF:
-  datatype: int16
+  datatype: float
   type: sensor
   unit: g/s
+  min: 0
+  max: 655.35
   description: PID 10 - Grams of air drawn into engine per second
 
 - ThrottlePosition:
@@ -161,6 +182,7 @@
   datatype: string
   type: sensor
   description: PID 12 - Secondary air status
+  #Issue: How is string supposed to be coded? Enum or uint8 instead?
 
 - O2:
   type: branch
@@ -178,6 +200,8 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 1.275
   description: PID 14 - Sensor voltage
 
 - O2.Bank1.Sensor2:
@@ -188,6 +212,8 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 1.275
   description: PID 15 - Sensor voltage
 
 - O2.Bank1.Sensor3:
@@ -198,6 +224,8 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 1.275
   description: PID 16 - Sensor voltage
 
 - O2.Bank1.Sensor4:
@@ -208,6 +236,8 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 1.275
   description: PID 17 - Sensor voltage
 
 - O2.Bank2:
@@ -222,6 +252,8 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 1.275
   description: PID 18 - Sensor voltage
 
 - O2.Bank2.Sensor2:
@@ -232,6 +264,8 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 1.275
   description: PID 19 - Sensor voltage
 
 - O2.Bank2.Sensor3:
@@ -242,6 +276,8 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 1.275
   description: PID 1A - Sensor voltage
 
 - O2.Bank2.Sensor4:
@@ -252,7 +288,11 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 1.275
   description: PID 1B - Sensor voltage
+
+# Issue: 1C missing?
 
 - O2Alt:
   type: branch
@@ -304,9 +344,11 @@
   description: PID 1E - Auxiliary input status (power take off)
 
 - RunTime:
-  datatype: uint32
+  datatype: uint16
   type: sensor
   unit: s
+  min: 0
+  max: 65535
   description: PID 1F - Engine run time
 
 - PidsB:
@@ -315,21 +357,27 @@
   description: PID 20 - Bit array of the supported pids 21 to 40
 
 - DistanceWithMIL:
-  datatype: uint32
+  datatype: uint16
   type: sensor
   unit: km
+  min: 0
+  max: 65535
   description: PID 21 - Distance traveled with MIL on
 
 - FuelRailPressureVac:
   datatype: float
   type: sensor
   unit: kPa
+  min: 0
+  max: 5177.265
   description: PID 22 - Fuel rail pressure relative to vacuum
 
 - FuelRailPressureDirect:
-  datatype: float
+  datatype: uint32
   type: sensor
   unit: kPa
+  min: 0
+  max: 655350
   description: PID 23 - Fuel rail pressure direct inject
 
 - O2WR:
@@ -344,12 +392,16 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 8
   description: PID 24 - Lambda voltage for wide range/band oxygen sensor 1
 
 - O2WR.Sensor1.Current:
   datatype: float
   type: sensor
   unit: A
+  min: -0.128
+  max: 0.128
   description: PID 34 - Lambda current for wide range/band oxygen sensor 1
 
 - O2WR.Sensor2:
@@ -360,12 +412,16 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 8
   description: PID 25 - Lambda voltage for wide range/band oxygen sensor 2
 
 - O2WR.Sensor2.Current:
   datatype: float
   type: sensor
   unit: A
+  min: -0.128
+  max: 0.128
   description: PID 35 - Lambda current for wide range/band oxygen sensor 2
 
 - O2WR.Sensor3:
@@ -376,12 +432,16 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 8
   description: PID 26 - Lambda voltage for wide range/band oxygen sensor 3
 
 - O2WR.Sensor3.Current:
   datatype: float
   type: sensor
   unit: A
+  min: -0.128
+  max: 0.128
   description: PID 36 - Lambda current for wide range/band oxygen sensor 4
 
 - O2WR.Sensor4:
@@ -392,12 +452,16 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 8
   description: PID 27 - Lambda voltage for wide range/band oxygen sensor 4
 
 - O2WR.Sensor4.Current:
   datatype: float
   type: sensor
   unit: A
+  min: -0.128
+  max: 0.128
   description: PID 37 - Lambda current for wide range/band oxygen sensor 4
 
 - O2WR.Sensor5:
@@ -408,12 +472,16 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 8
   description: PID 28 - Lambda voltage for wide range/band oxygen sensor 5
 
 - O2WR.Sensor5.Current:
   datatype: float
   type: sensor
   unit: A
+  min: -0.128
+  max: 0.128
   description: PID 38 - Lambda current for wide range/band oxygen sensor 5
 
 - O2WR.Sensor6:
@@ -424,12 +492,16 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 8
   description: PID 29 - Lambda voltage for wide range/band oxygen sensor 6
 
 - O2WR.Sensor6.Current:
   datatype: float
   type: sensor
   unit: A
+  min: -0.128
+  max: 0.128
   description: PID 39 - Lambda current for wide range/band oxygen sensor 6
 
 - O2WR.Sensor7:
@@ -440,12 +512,16 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 8
   description: PID 2A - Lambda voltage for wide range/band oxygen sensor 7
 
 - O2WR.Sensor7.Current:
   datatype: float
   type: sensor
   unit: A
+  min: -0.128
+  max: 0.128
   description: PID 3A - Lambda current for wide range/band oxygen sensor 7
 
 - O2WR.Sensor8:
@@ -456,59 +532,79 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 8
   description: PID 2B - Lambda voltage for wide range/band oxygen sensor 8
 
 - O2WR.Sensor8.Current:
   datatype: float
   type: sensor
   unit: A
+  min: -0.128
+  max: 0.128
   description: PID 3B - Lambda current for wide range/band oxygen sensor 8
 
 - CommandedEGR:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: PID 2C - Commanded exhaust gas recirculation (EGR)
 
 - EGRError:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: -100
+  max: 99.2
   description: PID 2D - Exhaust gas recirculation (EGR) error
 
 - CommandedEVAP:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: PID 2E - Commanded evaporative purge (EVAP) valve
 
 - FuelLevel:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: PID 2F - Fuel level in the fuel tank
 
 - WarmupsSinceDTCClear:
-  datatype: uint16
+  datatype: uint8
   type: sensor
+  min: 0
+  max: 255
   description: PID 30 - Number of warm-ups since codes cleared
 
 - DistanceSinceDTCClear:
-  datatype: float
+  datatype: uint16
   type: sensor
   unit: km
+  min: 0
+  max: 65535
   description: PID 31 - Distance traveled since codes cleared
 
 - EVAPVaporPressure:
   datatype: float
   type: sensor
   unit: Pa
+  min: -8192
+  max: 8191.75
   description: PID 32 - Evaporative purge (EVAP) system pressure
 
 - BarometricPressure:
-  datatype: float
+  datatype: uint8
   type: sensor
   unit: kPa
+  min: 0
+  max: 255
   description: PID 33 - Barometric pressure
 
 - Catalyst:
@@ -523,12 +619,16 @@
   datatype: float
   type: sensor
   unit: celsius
+  min: -40
+  max: 6513.5
   description: PID 3C - Catalyst temperature from bank 1, sensor 1
 
 - Catalyst.Bank1.Temperature2:
   datatype: float
   type: sensor
   unit: celsius
+  min: -40
+  max: 6513.5
   description: PID 3E - Catalyst temperature from bank 1, sensor 2
 
 - Catalyst.Bank2:
@@ -539,12 +639,16 @@
   datatype: float
   type: sensor
   unit: celsius
+  min: -40
+  max: 6513.5
   description: PID 3D - Catalyst temperature from bank 2, sensor 1
 
 - Catalyst.Bank2.Temperature2:
   datatype: float
   type: sensor
   unit: celsius
+  min: -40
+  max: 6513.5
   description: PID 3F - Catalyst temperature from bank 2, sensor 2
 
 - PidsC:
@@ -555,6 +659,7 @@
 - DriveCycleStatus:
   type: branch
   description: PID 41 - OBD status for the current drive cycle
+# Issue? This branch correct?
 
 - DriveCycleStatus.MIL:
   datatype: boolean
@@ -576,78 +681,104 @@
   datatype: float
   type: sensor
   unit: V
+  min: 0
+  max: 65535
   description: PID 42 - Control module voltage
 
 - AbsoluteLoad:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 25700
   description: PID 43 - Absolute load value
 
 - CommandedEquivalenceRatio:
   datatype: float
   type: sensor
   unit: ratio
+  min: 0
+  max: 2
   description: PID 44 - Commanded equivalence ratio
 
 - RelativeThrottlePosition:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: PID 45 - Relative throttle position
 
 - AmbientAirTemperature:
-  datatype: float
+  datatype: int16
   type: sensor
   unit: celsius
+  min: -40
+  max: 215
   description: PID 46 - Ambient air temperature
 
 - ThrottlePositionB:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: PID 47 - Absolute throttle position B
 
 - ThrottlePositionC:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: PID 48 - Absolute throttle position C
 
 - AcceleratorPositionD:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: PID 49 - Accelerator pedal position D
 
 - AcceleratorPositionE:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: PID 4A - Accelerator pedal position E
 
 - AcceleratorPositionF:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: PID 4B - Accelerator pedal position F
 
 - ThrottleActuator:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: PID 4C - Commanded throttle actuator
 
 - RunTimeMIL:
-  datatype: uint32
+  datatype: uint16
   type: sensor
   unit: min
+  min: 0
+  max: 65535
   description: PID 4D - Run time with MIL on
 
 - TimeSinceDTCCleared:
-  datatype: uint32
+  datatype: uint16
   type: sensor
   unit: min
+  min: 0
+  max: 65535
   description: PID 4E - Time since trouble codes cleared
 
 - MaxMAF:
@@ -655,86 +786,114 @@
   type: sensor
   unit: g/s
   description: PID 50 - Maximum flow for mass air flow sensor
+#Issue: This is actually four 1 uint8 values in OBD. Convert to branch?
 
 - FuelType:
   datatype: string
   type: sensor
   description: PID 51 - Fuel type
+# Issue - what values? Why not enum or uint8 values?
 
 - EthanolPercent:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: PID 52 - Percentage of ethanol in the fuel
 
 - EVAPVaporPressureAbsolute:
   datatype: float
   type: sensor
   unit: kPa
+  min: 0
+  max: 327.675
   description: PID 53 - Absolute evaporative purge (EVAP) system pressure
 
 - EVAPVaporPressureAlternate:
-  datatype: float
+  datatype: int32
   type: sensor
   unit: Pa
+  min: -32767
+  max: 32768
   description: PID 54 - Alternate evaporative purge (EVAP) system pressure
 
 - ShortTermO2Trim1:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: -100
+  max: 99.2
   description: PID 55 - Short term secondary O2 trim - Bank 1
 
 - LongTermO2Trim1:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: -100
+  max: 99.2
   description: PID 56 - Long term secondary O2 trim - Bank 1
 
 - ShortTermO2Trim2:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: -100
+  max: 99.2
   description: PID 57 - Short term secondary O2 trim - Bank 2
 
 - LongTermO2Trim2:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: -100
+  max: 99.2
   description: PID 58 - Long term secondary O2 trim - Bank 2
 
 - FuelRailPressureAbsolute:
-  datatype: float
+  datatype: uint32
   type: sensor
   unit: kPa
+  min: 0
+  max: 655350
   description: PID 59 - Absolute fuel rail pressure
 
 - RelativeAcceleratorPosition:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: PID 5A - Relative accelerator pedal position
 
 - HybridBatteryRemaining:
-  datatype: uint8
+  datatype: float
   type: sensor
   unit: percent
+  min: 0
+  max: 100
   description: PID 5B - Remaining life of hybrid battery
 
 - OilTemperature:
-  datatype: uint8
+  datatype: int16
   type: sensor
   unit: celsius
+  min: -40
+  max: 210
   description: PID 5C - Engine oil temperature
 
 - FuelInjectionTiming:
-  datatype: int16
+  datatype: float
   type: sensor
   unit: degrees
+  min: -210
+  max: 301.992
   description: PID 5D - Fuel injection timing
 
 - FuelRate:
   datatype: float
   type: sensor
   unit: l/h
+  min: 0
+  max: 3212.75
   description: PID 5E - Engine fuel rate


### PR DESCRIPTION
Possible changes to comply with supported values in OBD.

A lot of issues identified, like:

- Quite often we have int, but OBD supports float (well actually some scaled/offset value, e.g supporting 1/255, 2/255, ..., 254/255, 255/255 as percentage
- In some cases we have float, but not really needed, as only integer values are supported 