### PR TITLE
Removing aggregate keyword

### DIFF
--- a/docs-gen/content/rule_set/basics.md
+++ b/docs-gen/content/rule_set/basics.md
@@ -89,7 +89,6 @@ if the meta-data of the moved node hasn't changed.
 ```
 Navigation.CurrentLocation:
   type: branch
-  aggregate: true
   description: The current latitude and longitude of the vehicle.
   deprecation: V2.1 moved to Vehicle.CurrentLocation
 ```  

--- a/docs-gen/content/rule_set/branches.md
+++ b/docs-gen/content/rule_set/branches.md
@@ -12,7 +12,7 @@ A branch entry example is given below:
 ```YAML
 - Trunk:
   type: branch
-  aggregate: true
+  aggregate: false
   description: All signals related to the rear trunk
 ```
 
@@ -30,6 +30,10 @@ opposed to a signal entry). This is the default, in case ```type``` is omitted.
 * **```aggregate```** *[optional]*  
 Defines whether or not this branch is an aggregate.
 If not defined, this defaults to ```false```.
+An aggregate is a collection of signals that make sense to handle together in a system.
+A typical example could be GNSS location, where latitude and longitude make sense to read
+and write together. This is supposed to be deployment and tool specific,
+and for that reason no branches are aggregates by default in VSS.
 
 * **```description```**  
 A description string to be included (when applicable) in the various

--- a/spec/Cabin/Infotainment.vspec
+++ b/spec/Cabin/Infotainment.vspec
@@ -21,7 +21,6 @@
 
 - Media.Played:
   type: branch
-  aggregate: true
   description: Collection of signals updated in concert when a new media is played
 
 - Media.Played.Source:
@@ -73,7 +72,6 @@
 
 - Navigation.DestinationSet:
   type: branch
-  aggregate: true
   description: A navigation has been selected.
 
 - Navigation.DestinationSet.Latitude:
@@ -94,7 +92,6 @@
 
 - Navigation.CurrentLocation:
   type: branch
-  aggregate: true
   description: The current latitude and longitude of the vehicle.
   deprecation: V2.1 moved to Vehicle.CurrentLocation
 

--- a/spec/Private/CARFIT/Chassis/Wheel.vspec
+++ b/spec/Private/CARFIT/Chassis/Wheel.vspec
@@ -41,7 +41,6 @@
 #
 - Tire.Condition:
   type: Branch
-  aggregate: true
   description: All signals relating to the tire condition.
 
 - Tire.Condition.Tread:

--- a/spec/Vehicle/Vehicle.vspec
+++ b/spec/Vehicle/Vehicle.vspec
@@ -372,7 +372,6 @@
 
 - CurrentLocation:
   type: branch
-  aggregate: true
   description: The current latitude and longitude of the vehicle.
 
 - CurrentLocation.Latitude:


### PR DESCRIPTION
After this has been merged,  a separate PR for vss-tools
shall be merged to give error if keyword "aggregate" is used.